### PR TITLE
Fix AI test creation error handling

### DIFF
--- a/ContainEye.xcodeproj/project.pbxproj
+++ b/ContainEye.xcodeproj/project.pbxproj
@@ -621,7 +621,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "@executable_path/Frameworks";
 				"LD_RUNPATH_SEARCH_PATHS[sdk=macosx*]" = "@executable_path/../Frameworks";
 				MACOSX_DEPLOYMENT_TARGET = 15.0;
-				MARKETING_VERSION = 12;
+				MARKETING_VERSION = 13;
 				PRODUCT_BUNDLE_IDENTIFIER = com.nagel.ContainEye;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				REGISTER_APP_GROUPS = YES;
@@ -664,7 +664,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "@executable_path/Frameworks";
 				"LD_RUNPATH_SEARCH_PATHS[sdk=macosx*]" = "@executable_path/../Frameworks";
 				MACOSX_DEPLOYMENT_TARGET = 15.0;
-				MARKETING_VERSION = 12;
+				MARKETING_VERSION = 13;
 				PRODUCT_BUNDLE_IDENTIFIER = com.nagel.ContainEye;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				REGISTER_APP_GROUPS = YES;
@@ -787,7 +787,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 12;
+				MARKETING_VERSION = 13;
 				PRODUCT_BUNDLE_IDENTIFIER = com.nagel.ContainEye.TestsWidget;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				REGISTER_APP_GROUPS = YES;
@@ -821,7 +821,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 12;
+				MARKETING_VERSION = 13;
 				PRODUCT_BUNDLE_IDENTIFIER = com.nagel.ContainEye.TestsWidget;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				REGISTER_APP_GROUPS = YES;

--- a/ContainEye/Shared/LLM/Confirmator.swift
+++ b/ContainEye/Shared/LLM/Confirmator.swift
@@ -400,20 +400,43 @@ private struct Confirmator: View {
             // Error content
             VStack(spacing: 16) {
                 if let errorMessage = confirmator.errorMessage {
-                    Text(errorMessage)
-                        .font(.body)
-                        .foregroundStyle(.secondary)
-                        .multilineTextAlignment(.center)
-                        .lineLimit(nil)
-                        .padding()
-                        .background(.red.opacity(0.05), in: RoundedRectangle(cornerRadius: 12))
-                        .overlay(
-                            RoundedRectangle(cornerRadius: 12)
-                                .stroke(.red.opacity(0.2), lineWidth: 1)
-                        )
+                    VStack(alignment: .leading, spacing: 8) {
+                        HStack {
+                            Text("Details")
+                                .font(.caption)
+                                .fontWeight(.medium)
+                                .foregroundStyle(.secondary)
+
+                            Spacer()
+
+                            Button {
+                                UIPasteboard.general.string = errorMessage
+                            } label: {
+                                HStack(spacing: 4) {
+                                    Image(systemName: "doc.on.doc")
+                                    Text("Copy")
+                                }
+                                .font(.caption2)
+                                .foregroundStyle(.red)
+                            }
+                        }
+
+                        Text(errorMessage)
+                            .font(.body)
+                            .foregroundStyle(.secondary)
+                            .multilineTextAlignment(.leading)
+                            .lineLimit(nil)
+                            .frame(maxWidth: .infinity, alignment: .leading)
+                    }
+                    .padding()
+                    .background(.red.opacity(0.05), in: RoundedRectangle(cornerRadius: 12))
+                    .overlay(
+                        RoundedRectangle(cornerRadius: 12)
+                            .stroke(.red.opacity(0.2), lineWidth: 1)
+                    )
                 }
             }
-            
+
             // Actions
             Button("Dismiss") {
                 confirmator.clearError()

--- a/ContainEye/Shared/LLM/LLM.swift
+++ b/ContainEye/Shared/LLM/LLM.swift
@@ -33,38 +33,42 @@ enum LLM {
             // Append AI response to the conversation history
             conversation.append(["role": "assistant", "content": responseString])
 
-            // Define regex patterns for JSON syntax
-            let questionPattern = /"type":\s*"question".*?"content":\s*"([^"]+)"/.dotMatchesNewlines()
-            let executePattern = /"type":\s*"execute",.*?"content":\s*"([^"]+)"/.dotMatchesNewlines()
-
             var newInputs: [[String: String]] = []
 
-
-            print(responseString, responseString.matches(of: questionPattern).count, responseString.matches(of: executePattern).count)
-            // Process questions
-            for match in responseString.matches(of: questionPattern) {
-                let question = match.1
-                let answer = try await ConfirmatorManager.shared.ask(String(question))
-                let jsonResponse = """
-                {
-                    "type": "answer",
-                    "content": "\(answer)"
-                }
-                """
-                newInputs.append(["role": "user", "content": jsonResponse])
+            // Try to parse as JSON to handle questions and execute commands
+            struct AIResponse: Decodable {
+                let type: String
+                let content: String
             }
 
-            // Process commands
-            for match in responseString.matches(of: executePattern) {
-                let command = match.1
-                let result = try await ConfirmatorManager.shared.execute(String(command))
-                let jsonResponse = """
-                {
-                    "type": "command_output",
-                    "content": "\(result)"
-                }	
-                """
-                newInputs.append(["role": "user", "content": jsonResponse])
+            // Check if response is valid JSON
+            if let jsonData = responseString.data(using: .utf8),
+               let aiResponse = try? JSONDecoder().decode(AIResponse.self, from: jsonData) {
+
+                switch aiResponse.type {
+                case "question":
+                    let answer = try await ConfirmatorManager.shared.ask(aiResponse.content)
+                    let jsonResponse = """
+                    {
+                        "type": "answer",
+                        "content": "\(answer)"
+                    }
+                    """
+                    newInputs.append(["role": "user", "content": jsonResponse])
+
+                case "execute":
+                    let result = try await ConfirmatorManager.shared.execute(aiResponse.content)
+                    let jsonResponse = """
+                    {
+                        "type": "command_output",
+                        "content": "\(result)"
+                    }
+                    """
+                    newInputs.append(["role": "user", "content": jsonResponse])
+
+                default:
+                    break
+                }
             }
 
             // If new input exists, recurse with updated history

--- a/ContainEye/Shared/LLM/LLM.swift
+++ b/ContainEye/Shared/LLM/LLM.swift
@@ -48,23 +48,19 @@ enum LLM {
                 switch aiResponse.type {
                 case "question":
                     let answer = try await ConfirmatorManager.shared.ask(aiResponse.content)
-                    let jsonResponse = """
-                    {
-                        "type": "answer",
-                        "content": "\(answer)"
+                    // Properly encode JSON to handle quotes, newlines, etc.
+                    if let jsonData = try? JSONSerialization.data(withJSONObject: ["type": "answer", "content": answer]),
+                       let jsonResponse = String(data: jsonData, encoding: .utf8) {
+                        newInputs.append(["role": "user", "content": jsonResponse])
                     }
-                    """
-                    newInputs.append(["role": "user", "content": jsonResponse])
 
                 case "execute":
                     let result = try await ConfirmatorManager.shared.execute(aiResponse.content)
-                    let jsonResponse = """
-                    {
-                        "type": "command_output",
-                        "content": "\(result)"
+                    // Properly encode JSON to handle quotes, newlines, etc.
+                    if let jsonData = try? JSONSerialization.data(withJSONObject: ["type": "command_output", "content": result]),
+                       let jsonResponse = String(data: jsonData, encoding: .utf8) {
+                        newInputs.append(["role": "user", "content": jsonResponse])
                     }
-                    """
-                    newInputs.append(["role": "user", "content": jsonResponse])
 
                 default:
                     break

--- a/ContainEye/Shared/LLM/LLM.swift
+++ b/ContainEye/Shared/LLM/LLM.swift
@@ -75,8 +75,10 @@ enum LLM {
             return (responseString, conversation)
 
         } catch {
-
-            return await generate(prompt: prompt, systemPrompt: systemPrompt, history: history.suffix(3))
+            // Log error for debugging
+            print("LLM generation error: \(error)")
+            // Return error message instead of infinite retry
+            return ("Error: Failed to generate response - \(error.localizedDescription)", history)
         }
     }
 

--- a/ContainEye/Shared/Setup/AddTestView.swift
+++ b/ContainEye/Shared/Setup/AddTestView.swift
@@ -125,7 +125,11 @@ The regex/string must match exactly the entire output of the command. Consider u
                     TextField("Describe what to test", text: $testDescription, axis: .vertical)
                         .focused($field, equals: .askAI)
                     AsyncButton {
-                        test = try await generateTest(from: test, description: testDescription)
+                        do {
+                            test = try await generateTest(from: test, description: testDescription)
+                        } catch {
+                            await ConfirmatorManager.shared.reportError(error)
+                        }
                     } label: {
                         Image(systemName: "arrow.up.circle.fill")
                     }

--- a/ContainEye/Shared/Setup/AddTestView.swift
+++ b/ContainEye/Shared/Setup/AddTestView.swift
@@ -83,7 +83,7 @@ struct AddTestView: View {
                             screen = 3
                             _ = try? await UNUserNotificationCenter.current().requestAuthorization(options: [.alert, .sound, .badge])
                         } catch {
-                            await ConfirmatorManager.shared.reportError(error)
+                            await ConfirmatorManager.reportError(error)
                         }
                     }
                     .buttonStyle(.bordered)
@@ -113,7 +113,7 @@ which is what the test tried to verify. You must ask the user how to fix the tes
 The regex/string must match exactly the entire output of the command. Consider using | grep directly in the command.
 """)
                             } catch {
-                                await ConfirmatorManager.shared.reportError(error)
+                                await ConfirmatorManager.reportError(error)
                             }
                         }
                         .buttonStyle(.borderedProminent)
@@ -125,7 +125,7 @@ The regex/string must match exactly the entire output of the command. Consider u
                                 UserDefaults.standard.set(ContentView.Screen.testList.rawValue, forKey: "screen")
                                 _ = try? await UNUserNotificationCenter.current().requestAuthorization(options: [.alert, .sound, .badge])
                             } catch {
-                                await ConfirmatorManager.shared.reportError(error)
+                                await ConfirmatorManager.reportError(error)
                             }
                         }
                         .buttonStyle(.bordered)
@@ -140,7 +140,7 @@ The regex/string must match exactly the entire output of the command. Consider u
                         do {
                             test = try await generateTest(from: test, description: testDescription)
                         } catch {
-                            await ConfirmatorManager.shared.reportError(error)
+                            await ConfirmatorManager.reportError(error)
                         }
                     } label: {
                         Image(systemName: "arrow.up.circle.fill")

--- a/ContainEye/Shared/Setup/AddTestView.swift
+++ b/ContainEye/Shared/Setup/AddTestView.swift
@@ -137,6 +137,7 @@ The regex/string must match exactly the entire output of the command. Consider u
                     TextField("Describe what to test", text: $testDescription, axis: .vertical)
                         .focused($field, equals: .askAI)
                     AsyncButton {
+                        field = nil  // Dismiss keyboard when starting AI generation
                         do {
                             test = try await generateTest(from: test, description: testDescription)
                         } catch {
@@ -178,7 +179,6 @@ The regex/string must match exactly the entire output of the command. Consider u
         test.expectedOutput = output.content.expectedOutput
         test.notes = testDescription
         testDescription.removeAll()
-        field = nil
         currentHistory = dirtyLlmOutput.history
         return await test.test()
     }

--- a/ContainEye/Shared/Setup/AddTestView.swift
+++ b/ContainEye/Shared/Setup/AddTestView.swift
@@ -189,27 +189,52 @@ The regex/string must match exactly the entire output of the command. Consider u
         } catch let DecodingError.keyNotFound(key, context) {
             print("Missing field '\(key.stringValue)' in AI response")
             print("Raw response: \(llmOutput)")
+            let errorMsg = """
+            AI response is missing the field '\(key.stringValue)'.
+
+            Raw AI response:
+            \(llmOutput)
+
+            Please try again with a more specific description.
+            """
             throw NSError(
                 domain: "AITestGeneration",
                 code: 1,
-                userInfo: [NSLocalizedDescriptionKey: "AI response is missing the field '\(key.stringValue)'. Please try again with a more specific description."]
+                userInfo: [NSLocalizedDescriptionKey: errorMsg]
             )
         } catch let DecodingError.typeMismatch(type, context) {
             print("Type mismatch in AI response: expected \(type)")
             print("Context: \(context.debugDescription)")
             print("Raw response: \(llmOutput)")
+            let errorMsg = """
+            AI returned an unexpected response format.
+            Expected: \(type)
+
+            Raw AI response:
+            \(llmOutput)
+
+            Please try again.
+            """
             throw NSError(
                 domain: "AITestGeneration",
                 code: 2,
-                userInfo: [NSLocalizedDescriptionKey: "AI returned an unexpected response format. Please try again."]
+                userInfo: [NSLocalizedDescriptionKey: errorMsg]
             )
         } catch {
             print("JSON decoding failed: \(error)")
             print("Raw response: \(llmOutput)")
+            let errorMsg = """
+            Failed to understand AI response.
+
+            Raw AI response:
+            \(llmOutput)
+
+            Error: \(error.localizedDescription)
+            """
             throw NSError(
                 domain: "AITestGeneration",
                 code: 3,
-                userInfo: [NSLocalizedDescriptionKey: "Failed to understand AI response: \(error.localizedDescription)"]
+                userInfo: [NSLocalizedDescriptionKey: errorMsg]
             )
         }
         test.title = output.content.title


### PR DESCRIPTION
- Add error display using ConfirmatorManager when AI test generation fails
- Fix infinite retry loop in LLM.generate() by returning error message instead
- Users now see helpful error messages instead of silent failures

Fixes issue where AI test creation would fail silently with no user feedback.